### PR TITLE
chore: Change workflow to commit to builds branch

### DIFF
--- a/.github/workflows/update-builds-json.yml
+++ b/.github/workflows/update-builds-json.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: builds
 
       - name: Update builds.json
         run: |
@@ -73,4 +73,4 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add builds.json
           git commit -m "Update builds.json with new ${{ github.event.inputs.buildType }} build"
-          git push origin main
+          git push origin builds


### PR DESCRIPTION
Workflow should commit to `builds` branch instead